### PR TITLE
Generator: class-linking.

### DIFF
--- a/src/PHPDocMD/Generator.php
+++ b/src/PHPDocMD/Generator.php
@@ -176,7 +176,7 @@ class Generator
 
             } else {
 
-                $returnedClasses[] = "[" . $myLabel . "](" . str_replace('\\', '-', $oneClass) . ')';
+                $returnedClasses[] = "[" . $myLabel . "](" . str_replace('\\', '-', $oneClass) . '.md)';
 
             }
 


### PR DESCRIPTION
The links should point to the .md file itself. Without the .md extension
you'll get a 404.

I noticed that the APIIndex 404'd my links. This fixes the issue. As you can see in the following blog post, the .md is mandatory: https://github.com/blog/1395-relative-links-in-markup-files

As you can see, it works properly in my repository: https://github.com/siphoc/PdfBundle/blob/master/Resources/doc/ApiIndex.md
