### PR TITLE
This stops Github from highlighting "errors" in the signature code blocks

### DIFF
--- a/templates/class.twig
+++ b/templates/class.twig
@@ -40,7 +40,7 @@ Constants
 
 ### {{ constant.name }}
 
-```
+```dummy
 {{ constant.signature|raw }}
 ```
 
@@ -60,7 +60,7 @@ Properties
 
 ### {{ property.name }}
 
-```
+```dummy
 {{ property.signature|raw }}
 ```
 
@@ -85,7 +85,7 @@ Methods
 
 ### {{ method.name }}
 
-```
+```dummy
 {{ method.signature|raw }}
 ```
 


### PR DESCRIPTION
Specified the non-existent language, "dummy", on the code blocks which display signatures.
This stops Github from guessing the language and highlighting "errors" in the signature.