### PR TITLE
Upgrade twig

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Options
         This specifies the 'template' for links we're generating. By default
         this is "%c.md".
 
+    --index [filename]
+        This specifies the 'filename' for API Index markdown file we're generating.
+        By default this is "ApiIndex.md".
+
 This should generate all the .md files. I'm excited to hear your feedback.
 
 Cheers,

--- a/bin/phpdocmd
+++ b/bin/phpdocmd
@@ -63,7 +63,7 @@ echo "Parsing structure.xml\n";
 
 $classDefinitions = $parser->run();
 
-$templateDir = __DIR__ . '/../templates/';
+$templateDir = dirname(__DIR__).'/templates/';
 
 $generator = new PHPDocMD\Generator(
     $classDefinitions,

--- a/bin/phpdocmd
+++ b/bin/phpdocmd
@@ -32,6 +32,7 @@ $positional = array();
 
 $named = array(
     'lt' => '%c.md',
+    'index' => 'ApiIndex.md',
 );
 
 for ($i = 0; $i < count($arguments); $i++) {
@@ -63,13 +64,14 @@ echo "Parsing structure.xml\n";
 
 $classDefinitions = $parser->run();
 
-$templateDir = dirname(__DIR__).'/templates/';
+$templateDir = dirname(__DIR__) . '/templates/';
 
 $generator = new PHPDocMD\Generator(
     $classDefinitions,
     $outputDir,
     $templateDir,
-    $named['lt']
+    $named['lt'],
+    $named['index']
 );
 
 echo "Generating pages\n";

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license" : "MIT",
     "require" : {
         "php" : ">=5.3.1",
-        "twig/twig" : "~1.18.0"
+        "twig/twig" : "~1.2|2.0"
     },
     "require-dev" : {
         "phpdocumentor/phpdocumentor" : "~2.8.0"

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -77,18 +77,14 @@ class Generator
         $twig->addFilter($filter);
 
         foreach ($this->classDefinitions as $className => $data) {
-            $output = $twig->render(
-                file_get_contents($this->templateDir . '/class.twig'),
-                $data
-            );
+            $output = $twig->render('class.twig', $data);
 
             file_put_contents($this->outputDir . '/' . $data['fileName'], $output);
         }
 
         $index = $this->createIndex();
 
-        $index = $twig->render(
-            file_get_contents($this->templateDir . '/index.twig'),
+        $index = $twig->render('index.twig',
             array(
                 'index'            => $index,
                 'classDefinitions' => $this->classDefinitions,

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -3,8 +3,8 @@
 namespace PHPDocMD;
 
 use Twig_Environment;
-use Twig_Filter_Function;
-use Twig_Loader_String;
+use Twig_Loader_Filesystem;
+use Twig_SimpleFilter;
 
 /**
  * This class takes the output from 'parser', and generate the markdown
@@ -63,13 +63,18 @@ class Generator
      */
     public function run()
     {
-        $loader = new Twig_Loader_String();
+        $loader = new Twig_Loader_Filesystem($this->templateDir, array(
+            'cache' => false,
+            'debug' => true,
+        ));
+
         $twig = new Twig_Environment($loader);
 
         $GLOBALS['PHPDocMD_classDefinitions'] = $this->classDefinitions;
         $GLOBALS['PHPDocMD_linkTemplate'] = $this->linkTemplate;
 
-        $twig->addFilter('classLink', new Twig_Filter_Function('PHPDocMd\Generator::classLink'));
+        $filter = new Twig_SimpleFilter('classLink', array('PHPDocMd\\Generator', 'classLink'));
+        $twig->addFilter($filter);
 
         foreach ($this->classDefinitions as $className => $data) {
             $output = $twig->render(

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -45,17 +45,26 @@ class Generator
     protected $linkTemplate;
 
     /**
+     * Filename for API Index.
+     *
+     * @var string
+     */
+    protected $apiIndexFile;
+
+    /**
      * @param array  $classDefinitions
      * @param string $outputDir
      * @param string $templateDir
      * @param string $linkTemplate
+     * @param string $apiIndexFile
      */
-    public function __construct(array $classDefinitions, $outputDir, $templateDir, $linkTemplate = '%c.md')
+    public function __construct(array $classDefinitions, $outputDir, $templateDir, $linkTemplate = '%c.md', $apiIndexFile = 'ApiIndex.md')
     {
         $this->classDefinitions = $classDefinitions;
         $this->outputDir = $outputDir;
         $this->templateDir = $templateDir;
         $this->linkTemplate = $linkTemplate;
+        $this->apiIndexFile = $apiIndexFile;
     }
 
     /**
@@ -91,7 +100,7 @@ class Generator
             )
         );
 
-        file_put_contents($this->outputDir . '/ApiIndex.md', $index);
+        file_put_contents($this->outputDir . '/' . $this->apiIndexFile, $index);
     }
 
     /**


### PR DESCRIPTION
## What this did
- Upgraded the twig version to `~1.2|2.0` in `composer.json`. 
- Using [Twig_Loader_Filesystem](http://twig.sensiolabs.org/api/master/Twig_Loader_Filesystem.html) for twig loader and adding `classLink` filter with [Twig_SimpleFilter](http://twig.sensiolabs.org/api/master/Twig_SimpleFilter.html) instead of using `deprecated` classes `Twig_Filter_Function` and `Twig_Loader_String`, which are planned for removal in twig 2.0. 
- Adding way to override the default `ApiIndex.md` filename by using `--index Home.md` when using `phpdocmd` bin.

## Testing
```
"require-dev" : {
    "evert/phpdoc-md" : "dev-upgrade-twig"
},
"repositories": [
    {
        "type": "git",
        "url": "git@github.com:ericdowell/phpdoc-md.git"
    }
],
```
Or via https: `"url": "https://github.com/ericdowell/phpdoc-md.git"`