### PR TITLE
Add twig and parse logic for autoloaded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+docs-test/
+output-test/
 vendor/
 composer.lock
 .*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,7 @@ before_script:
 script:
     - find Core -name "*.php" | xargs -n1 php -l 
     - ./bin/sabre-cs-fixer fix . --dry-run --diff
+    - php bin/phpdoc.php -d src -t docs-test/ --template="xml"
+    - mkdir output-test
+    - php bin/phpdocmd docs-test/structure.xml output-test/
 

--- a/src/AbstractDefinition.php
+++ b/src/AbstractDefinition.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: eric
+ * Date: 2/11/16
+ * Time: 7:40 PM
+ */
+
+namespace PHPDocMD;
+
+use SimpleXmlElement;
+
+abstract class AbstractDefinition
+{
+    /**
+     * @var SimpleXmlElement
+     */
+    protected $xml;
+
+    /**
+     * @param SimpleXmlElement $xml
+     */
+    function __construct(SimpleXmlElement $xml)
+    {
+        $this->xml = $xml;
+    }
+
+    /**
+     * @return $this
+     */
+    abstract function parse();
+
+    /**
+     * @param array $classDefinitions
+     *
+     * @return $this
+     */
+    abstract function expand(array $classDefinitions);
+
+    /**
+     * @return string
+     */
+    abstract function getName();
+
+    /**
+     * @param $name
+     *
+     * @return mixed|void
+     */
+    function __get($name)
+    {
+        if (property_exists($this, $name)) {
+            return $this->{$name};
+        }
+    }
+}

--- a/src/Definition/ClassDefinition.php
+++ b/src/Definition/ClassDefinition.php
@@ -1,0 +1,379 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: eric
+ * Date: 2/11/16
+ * Time: 7:45 PM
+ */
+
+namespace PHPDocMD\Definition;
+
+use PHPDocMD\AbstractDefinition;
+
+class ClassDefinition extends AbstractDefinition
+{
+    /***
+     * @var string
+     */
+    public $fileName;
+    /**
+     * @var string
+     */
+    public $className;
+    /**
+     * @var string
+     */
+    public $shortClass;
+    /**
+     * @var string
+     */
+    public $namespace;
+    /**
+     * @var string
+     */
+    public $description;
+    /**
+     * @var string
+     */
+    public $longDescription;
+    /**
+     * @var array
+     */
+    public $implements = [];
+    /**
+     * @var array
+     */
+    public $extends = [];
+    /**
+     * @var bool
+     */
+    public $isClass;
+    /**
+     * @var bool
+     */
+    public $isInterface;
+    /**
+     * @var bool
+     */
+    public $abstract;
+    /**
+     * @var bool
+     */
+    public $deprecated;
+    /**
+     * @var array
+     */
+    public $methods;
+    /**
+     * @var array
+     */
+    public $properties;
+    /**
+     * @var array
+     */
+    public $constants;
+
+    /**
+     * @return string
+     */
+    function getName()
+    {
+        return $this->className;
+    }
+
+    /**
+     * @return $this
+     */
+    function parse()
+    {
+        $className = (string)$this->xml->full_name;
+        $className = ltrim($className, '\\');
+
+        $fileName = str_replace('\\', '-', $className) . '.md';
+
+        $implements = [];
+
+        if (isset($this->xml->implements)) {
+            foreach ($this->xml->implements as $interface) {
+                $implements[] = ltrim((string)$interface, '\\');
+            }
+        }
+
+        $extends = [];
+
+        if (isset($this->xml->extends)) {
+            foreach ($this->xml->extends as $parent) {
+                $extends[] = ltrim((string)$parent, '\\');
+            }
+        }
+
+        $this->fileName = $fileName;
+        $this->className = $className;
+        $this->shortClass = (string)$this->xml->name;
+        $this->namespace = (string)$this->xml['namespace'];
+        $this->description = (string)$this->xml->docblock->description;
+        $this->longDescription = (string)$this->xml->docblock->{'long-description'};
+        $this->implements = $implements;
+        $this->extends = $extends;
+        $this->isClass = $this->xml->getName() === 'class';
+        $this->isInterface = $this->xml->getName() === 'interface';
+        $this->abstract = (string)$this->xml['abstract'] == 'true';
+        $this->deprecated = count($this->xml->xpath('docblock/tag[@name="deprecated"]')) > 0;
+        $this->methods = $this->parseMethods();
+        $this->properties = $this->parseProperties();
+        $this->constants = $this->parseConstants();
+
+        return $this;
+    }
+
+    /**
+     * @param array $classDefinitions
+     *
+     * @return $this
+     */
+    function expand(array $classDefinitions)
+    {
+        $this->expandMethods($classDefinitions, $this->getName());
+        $this->expandProperties($classDefinitions, $this->getName());
+
+        return $this;
+    }
+
+    /**
+     * Parses all the method information for a single class or interface.
+     *
+     * You must pass an xml element that refers to either the class or interface element from
+     * structure.xml.
+     *
+     * @return array
+     */
+    protected function parseMethods()
+    {
+        $methods = [];
+
+        $className = (string)$this->xml->full_name;
+        $className = ltrim($className, '\\');
+
+        foreach ($this->xml->method as $method) {
+            $methodName = (string)$method->name;
+
+            $return = $method->xpath('docblock/tag[@name="return"]');
+
+            if (count($return)) {
+                $return = (string)$return[0]['type'];
+            }
+            else {
+                $return = 'mixed';
+            }
+
+            $arguments = [];
+
+            foreach ($method->argument as $argument) {
+                $nArgument = [
+                    'type' => (string)$argument->type,
+                    'name' => (string)$argument->name,
+                ];
+
+                $tags = $method->xpath(
+                    sprintf('docblock/tag[@name="param" and @variable="%s"]', $nArgument['name'])
+                );
+
+                if (count($tags)) {
+                    $tag = $tags[0];
+
+                    if ((string)$tag['type']) {
+                        $nArgument['type'] = (string)$tag['type'];
+                    }
+
+                    if ((string)$tag['description']) {
+                        $nArgument['description'] = (string)$tag['description'];
+                    }
+
+                    if ((string)$tag['variable']) {
+                        $nArgument['name'] = (string)$tag['variable'];
+                    }
+                }
+
+                $arguments[] = $nArgument;
+            }
+
+            $argumentStr = implode(', ', array_map(function ($argument) {
+                $return = $argument['name'];
+
+                if ($argument['type']) {
+                    $return = $argument['type'] . ' ' . $return;
+                }
+
+                return $return;
+            }, $arguments));
+
+            $signature = sprintf('%s %s::%s(%s)', $return, $className, $methodName, $argumentStr);
+
+            $methods[$methodName] = [
+                'name' => $methodName,
+                'description' => (string)$method->docblock->description . "\n\n" . (string)$method->docblock->{'long-description'},
+                'visibility' => (string)$method['visibility'],
+                'abstract' => ((string)$method['abstract']) == "true",
+                'static' => ((string)$method['static']) == "true",
+                'deprecated' => count($this->xml->xpath('docblock/tag[@name="deprecated"]')) > 0,
+                'signature' => $signature,
+                'arguments' => $arguments,
+                'definedBy' => $className,
+            ];
+        }
+
+        return $methods;
+    }
+
+    /**
+     * Parses all property information for a single class or interface.
+     *
+     * You must pass an xml element that refers to either the class or interface element from
+     * structure.xml.
+     *
+     * @return array
+     */
+    protected function parseProperties()
+    {
+        $properties = [];
+
+        $className = (string)$this->xml->full_name;
+        $className = ltrim($className, '\\');
+
+        foreach ($this->xml->property as $xProperty) {
+            $type = 'mixed';
+            $propName = (string)$xProperty->name;
+            $default = (string)$xProperty->default;
+
+            $xVar = $xProperty->xpath('docblock/tag[@name="var"]');
+
+            if (count($xVar)) {
+                $type = $xVar[0]->type;
+            }
+
+            $visibility = (string)$xProperty['visibility'];
+            $signature = sprintf('%s %s %s', $visibility, $type, $propName);
+
+            if ($default) {
+                $signature .= ' = ' . $default;
+            }
+
+            $properties[$propName] = [
+                'name' => $propName,
+                'type' => $type,
+                'default' => $default,
+                'description' => (string)$xProperty->docblock->description . "\n\n" . (string)$xProperty->docblock->{'long-description'},
+                'visibility' => $visibility,
+                'static' => ((string)$xProperty['static']) == 'true',
+                'signature' => $signature,
+                'deprecated' => count($this->xml->xpath('docblock/tag[@name="deprecated"]')) > 0,
+                'definedBy' => $className,
+            ];
+        }
+
+        return $properties;
+    }
+
+    /**
+     * Parses all constant information for a single class or interface.
+     *
+     * You must pass an xml element that refers to either the class or interface element from
+     * structure.xml.
+     *
+     * @return array
+     */
+    protected function parseConstants()
+    {
+        $constants = [];
+
+        $className = (string)$this->xml->full_name;
+        $className = ltrim($className, '\\');
+
+        foreach ($this->xml->constant as $xConstant) {
+            $name = (string)$xConstant->name;
+            $value = (string)$xConstant->value;
+
+            $signature = sprintf('const %s = %s', $name, $value);
+
+            $constants[$name] = [
+                'name' => $name,
+                'description' => (string)$xConstant->docblock->description . "\n\n" . (string)$xConstant->docblock->{'long-description'},
+                'signature' => $signature,
+                'value' => $value,
+                'deprecated' => count($this->xml->xpath('docblock/tag[@name="deprecated"]')) > 0,
+                'definedBy' => $className,
+            ];
+        }
+
+        return $constants;
+    }
+
+    /**
+     * This method goes through all the class definitions, and adds non-overridden method
+     * information from parent classes.
+     *
+     * @param array  $classDefinitions
+     * @param string $className
+     *
+     * @return array
+     */
+    protected function expandMethods(array $classDefinitions, $className)
+    {
+        $class = $classDefinitions[$className];
+        $newMethods = [];
+        foreach (array_merge($class->extends, $class->implements) as $extends) {
+            if (!isset($classDefinitions[$extends])) {
+                continue;
+            }
+            foreach ($classDefinitions[$extends]->methods as $methodName => $methodInfo) {
+                if (!isset($class->{$methodName})) {
+                    $newMethods[$methodName] = $methodInfo;
+                }
+            }
+            $newMethods = array_merge($newMethods, $this->expandMethods($classDefinitions, $extends));
+        }
+
+        $this->methods = array_merge(
+            $this->methods,
+            $newMethods
+        );
+
+        return $newMethods;
+    }
+
+    /**
+     * This method goes through all the class definitions, and adds non-overridden property
+     * information from parent classes.
+     *
+     * @param array  $classDefinitions
+     * @param string $className
+     *
+     * @return array
+     */
+    protected function expandProperties(array $classDefinitions, $className)
+    {
+        $class = $classDefinitions[$className];
+
+        $newProperties = [];
+
+        foreach (array_merge($class->implements, $class->extends) as $extends) {
+            if (!isset($classDefinitions[$extends])) {
+                continue;
+            }
+            foreach ($classDefinitions[$extends]->properties as $propertyName => $propertyInfo) {
+                if ($propertyInfo['visibility'] === 'private') {
+                    continue;
+                }
+                if (!isset($class->{$propertyName})) {
+                    $newProperties[$propertyName] = $propertyInfo;
+                }
+            }
+
+            $newProperties = array_merge($newProperties, $this->expandProperties($classDefinitions, $extends));
+        }
+
+        $this->properties += $newProperties;
+
+        return $newProperties;
+    }
+}

--- a/src/Definition/FunctionDefinition.php
+++ b/src/Definition/FunctionDefinition.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: eric
+ * Date: 2/11/16
+ * Time: 8:57 PM
+ */
+
+namespace PHPDocMD\Definition;
+
+use PHPDocMD\AbstractDefinition;
+
+class FunctionDefinition extends AbstractDefinition
+{
+
+    /**
+     * @return $this
+     */
+    function parse()
+    {
+        // TODO: Implement parse() method.
+    }
+
+    /**
+     * @param array $classDefinitions
+     *
+     * @return $this
+     */
+    function expand(array $classDefinitions)
+    {
+        // TODO: Implement expand() method.
+    }
+
+    /**
+     * @return string
+     */
+    function getName()
+    {
+        // TODO: Implement getName() method.
+    }
+}

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -85,10 +85,10 @@ class Generator
         $filter = new Twig_SimpleFilter('classLink', ['PHPDocMd\\Generator', 'classLink']);
         $twig->addFilter($filter);
 
-        foreach ($this->classDefinitions as $className => $data) {
-            $output = $twig->render('class.twig', $data);
+        foreach ($this->classDefinitions as $definition) {
+            $output = $twig->render('class.twig', ['definition' => $definition]);
 
-            file_put_contents($this->outputDir . '/' . $data['fileName'], $output);
+            file_put_contents($this->outputDir . '/' . $definition->fileName, $output);
         }
 
         $index = $this->createIndex();
@@ -115,7 +115,7 @@ class Generator
     {
         $tree = [];
 
-        foreach ($this->classDefinitions as $className => $classInfo) {
+        foreach ($this->classDefinitions as $className => $definition) {
             $current = & $tree;
 
             foreach (explode('\\', $className) as $part) {

--- a/templates/class.twig
+++ b/templates/class.twig
@@ -1,42 +1,41 @@
-{{ className }}
+{{ definition.className }}
 ===============
 
-{{ description }}
+{{ definition.description }}
 
-{{ longDescription|raw }}
+{{ definition.longDescription|raw }}
 
-{% if isClass %}
-
-* Class name: {{ shortClass }}
-* Namespace: {{ namespace }}
-{% if abstract %}* This is an **abstract** class
+{% if definition.isClass %}
+* Class name: {{ definition.shortClass }}
+* Namespace: {{ definition.namespace }}
+{% if definition.abstract %}* This is an **abstract** class
 {% endif %}
-{% if extends[0] %}* Parent class: {{ extends.0|classLink }}
+{% if definition.extends[0] %}* Parent class: {{ definition.extends.0|classLink }}
 {% endif %}
-{% if implements %}* This class implements: {% for interface in implements %}{{ interface|classLink }}{%if not loop.last %}, {% endif %}{% endfor %}
+{% if definition.implements %}* This class implements: {% for interface in definition.implements %}{{ interface|classLink }}{%if not loop.last %}, {% endif %}{% endfor %}
 {% endif %}
-{% if deprecated %}* **Warning:** this class is **deprecated**. This means that this class will likely be removed in a future version.
-{% endif %}
-
+{% if definition.deprecated %}* **Warning:** this class is **deprecated**. This means that this class will likely be removed in a future version.
 {% endif %}
 
-{% if isInterface %}
-* Interface name: {{ shortClass }}
-* Namespace: {{ namespace }}
+{% endif %}
+
+{% if definition.isInterface %}
+* Interface name: {{ definition.shortClass }}
+* Namespace: {{ definition.namespace }}
 * This is an **interface**
-{% if extends %}* This interface extends: {% for interface in extends %}{{ interface|classLink }}{%if not loop.last %}, {% endif %}{% endfor %}
+{% if definition.extends %}* This interface extends: {% for interface in definition.extends %}{{ interface|classLink }}{%if not loop.last %}, {% endif %}{% endfor %}
 {% endif %}
-{% if deprecated %}* **Warning:** this interface is **deprecated**. This means that this interface will likely be removed in a future version.
-{% endif %}
-
+{% if definition.deprecated %}* **Warning:** this interface is **deprecated**. This means that this interface will likely be removed in a future version.
 {% endif %}
 
-{% if constants %}
+{% endif %}
+
+{% if definition.constants %}
 Constants
 ----------
 {% endif %}
 
-{% for constant in constants %}
+{% for constant in definition.constants %}
 
 ### {{ constant.name }}
 
@@ -49,12 +48,12 @@ Constants
 
 {% endfor %}
 
-{% if properties %}
+{% if definition.properties %}
 Properties
 ----------
 {% endif %}
 
-{% for property in properties %}
+{% for property in definition.properties %}
 
 ### {{ property.name }}
 
@@ -72,12 +71,12 @@ Properties
 
 {% endfor %}
 
-{% if methods %}
+{% if definition.methods %}
 Methods
 -------
 {% endif %}
 
-{% for method in methods %}
+{% for method in definition.methods %}
 
 ### {{ method.name }}
 


### PR DESCRIPTION
## What this did
Initial start on refactoring Parser to allow functions (autoloaded files) to flow into api documentation.

- Adding an AbstractDefinition for typehinting. Moving parse and expand logic from Parser class into ClassDefinition class.
- Refactoring `parseMethods`, `parseProperties`, `parseConstants`, `expandMethods`, and `expandProperties` methods to work in the ClassDefintion class.
- Very minor tweaks to Generator class and class.twig.
- Adding commands to travis to test the bin file.
- Adding folders generated by commands in travis to .gitignore

Issue: evert/phpdoc-md#12