### PR TITLE
Multiblock args

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license" : "MIT",
     "require" : {
         "php" : ">=5.3.1",
+        "league/html-to-markdown" : "~4.8.2",
         "twig/twig" : "~1.2|2.0"
     },
     "require-dev" : {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -395,10 +395,10 @@ class Parser
             return $blocks[0];
         }
 
-        return array_map(function ($block) {
+        return array_map(function($block) {
             $lines = explode("\n", $block);
 
-            $lines = array_map(function ($line) {
+            $lines = array_map(function($line) {
                 return '    ' . $line;
             }, $lines);
 

--- a/templates/class.twig
+++ b/templates/class.twig
@@ -42,7 +42,7 @@ Constants
 
     {{ constant.signature|raw }}
 
-{{ property.description|raw }}
+{{ constant.description|raw }}
 
 {% if constant.deprecated %}* **Warning:** this constant is **deprecated**. This means that this constant will likely be removed in a future version.
 {% endif %}

--- a/templates/class.twig
+++ b/templates/class.twig
@@ -99,7 +99,13 @@ Methods
 {% if method.arguments %}
 #### Arguments
 {% for argument in method.arguments %}
-* {{ argument.name }} **{% if argument.type %}{{ argument.type|classLink }}{% else %}mixed{% endif %}**{% if argument.description %} - {{ argument.description }}{% endif %}
+* {{ argument.name }} **{% if argument.type %}{{ argument.type|classLink }}{% else %}mixed{% endif %}**{% if argument.description %}{% if argument.description is iterable %}
+
+
+{% for block_ in argument.description %}
+{{ block_|raw }}
+
+{% endfor %}{% else %} - {{ argument.description|raw }}{% endif %}{% endif %}
 
 {% endfor %}
 


### PR DESCRIPTION
This change allows the tool to generate expected Markdown code for method arguments when they have descriptions with complex structures.

For example, given the following docblock:

```php
/**
 * @param string[] $scopes
 *        The OneDrive scopes requested by the application. Supported
 *        values:
 *          - `'offline_access'` ;
 *          - `'files.read'` ;
 *          - `'files.read.all'` ;
 *          - `'files.readwrite'` ;
 *          - `'files.readwrite.all'`.
 * @param string $redirectUri
 *        The URI to which to redirect to upon successful log in.
 */
```

Without this change, the tool generates:

```
#### Arguments
* $scopes **array&lt;mixed,string&gt;** - &lt;p&gt;The OneDrive scopes requested by the application. Supported
values:&lt;/p&gt;
&lt;ul&gt;
&lt;li&gt;&lt;code&gt;&#039;offline_access&#039;&lt;/code&gt; ;&lt;/li&gt;
&lt;li&gt;&lt;code&gt;&#039;files.read&#039;&lt;/code&gt; ;&lt;/li&gt;
&lt;li&gt;&lt;code&gt;&#039;files.read.all&#039;&lt;/code&gt; ;&lt;/li&gt;
&lt;li&gt;&lt;code&gt;&#039;files.readwrite&#039;&lt;/code&gt; ;&lt;/li&gt;
&lt;li&gt;&lt;code&gt;&#039;files.readwrite.all&#039;&lt;/code&gt;.&lt;/li&gt;
&lt;/ul&gt;
* $redirectUri **string** - &lt;p&gt;The URI to which to redirect to upon successful log in.&lt;/p&gt;
```

The problem is that the encoded HTML - which came directly from attributes in the structure.xml generated by phpDocumentor - is rendered as-is in the Markdown file: HTML elements are shown as literal `<li>`, `<code>`, `&#039;`, etc... This problem is exacerbated by the fact that single line breaks are replaced by spaces as per Markdown specification. Ultimately, the description is close to unreadable. This is what you see when viewing the Markdown page on GitHub:

```
$scopes array<mixed,string> - <p>The OneDrive scopes requested by the application. Supported values:</p> <ul> <li><code>'offline_access'</code> ;</li> <li><code>'files.read'</code> ;</li> <li><code>'files.read.all'</code> ;</li> <li><code>'files.readwrite'</code> ;</li> <li><code>'files.readwrite.all'</code>.</li> </ul>
```

With this change, the tool generates:

```
#### Arguments
* $scopes **array&lt;mixed,string&gt;**

    The OneDrive scopes requested by the application. Supported values:

    - `'offline_access'` ;
    - `'files.read'` ;
    - `'files.read.all'` ;
    - `'files.readwrite'` ;
    - `'files.readwrite.all'`.


* $redirectUri **string** - The URI to which to redirect to upon successful log in.
```

This produces a much more Markdown-friendly description, close to the HTML version that phpDocumentor would generate. It becomes more readable, example here: https://github.com/krizalys/onedrive-php-sdk/wiki/Krizalys-Onedrive-Client