### PR TITLE
Prevent HTML tags in argument descriptions

### DIFF
--- a/templates/class.twig
+++ b/templates/class.twig
@@ -99,7 +99,7 @@ Methods
 {% if method.arguments %}
 #### Arguments
 {% for argument in method.arguments %}
-* {{ argument.name }} **{% if argument.type %}{{ argument.type|classLink }}{% else %}mixed{% endif %}**{% if argument.description %} - {{ argument.description }}{% endif %}
+* {{ argument.name }} **{% if argument.type %}{{ argument.type|classLink }}{% else %}mixed{% endif %}**{% if argument.description %} - {{ argument.description|striptags }}{% endif %}
 
 {% endfor %}
 


### PR DESCRIPTION
## Behaviour Before the Fix

An argument document block like:

```php
/**
 * @param mixed $input Only parameter the function will listen to.
 */
```

Is transformed into:

```
* $input **mixed** - <p>Only parameter the function will listen to.</p>
```

## Behaviour After the Fix

With this fix, the same input would be transformed into:

```
* $input **mixed** - Only parameter the function will listen to.
```

## Related Pull Requests

This pull request is a quick fix related with: !22 and may not be needed with it.

